### PR TITLE
feat: add update check and launch at login

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -6,6 +6,7 @@ const __dirname = dirname(__filename);
 
 export const APP_NAME = "PawPal";
 export const STORE_NAME = "pawpal";
+export const RELEASES_API_URL = "https://api.github.com/repos/zebangeth/PawPal/releases/latest";
 export const RELEASES_URL = "https://github.com/zebangeth/PawPal/releases";
 
 export const PET_WINDOW = {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -30,7 +30,8 @@ import type {
   Settings,
   StatsHistory,
   SpeechBubble,
-  TodayStats
+  TodayStats,
+  UpdateCheckResult
 } from "../shared/types";
 import {
   APP_NAME,
@@ -41,6 +42,7 @@ import {
   IS_DEV,
   PET_WINDOW,
   PRELOAD_PATH,
+  RELEASES_API_URL,
   RELEASES_URL,
   RENDERER_HTML_PATH,
   SETTINGS_WINDOW,
@@ -108,6 +110,14 @@ let distractionStatus: DistractionStatus = {
   lastWarningAt: null,
   error: null
 };
+let updateCheck: UpdateCheckResult = {
+  status: "idle",
+  currentVersion: app.getVersion(),
+  latestVersion: null,
+  releaseUrl: RELEASES_URL,
+  checkedAt: null,
+  error: null
+};
 
 function getSettings(): Settings {
   const stored = store.get("settings");
@@ -129,12 +139,38 @@ function setSettings(next: Settings): void {
     language: resolveLanguage(next.language),
     petAppearanceId: resolvePetAppearanceId(next.petAppearanceId)
   };
+  applyLaunchAtLoginPreference(normalized.launchAtLoginEnabled);
   store.set("settings", normalized);
-  sendToAll("settings:updated", normalized);
+  sendToAll("settings:updated", getSettingsWithSystemState());
   settingsWindow?.setTitle(`${APP_NAME} ${text().menu.settings}`);
   scheduleReminderTimers();
   scheduleDistractionDetection();
   updateTrayMenu();
+}
+
+function supportsLoginItemSettings(): boolean {
+  return (process.platform === "darwin" || process.platform === "win32") && app.isPackaged;
+}
+
+function applyLaunchAtLoginPreference(enabled: boolean): void {
+  if (!supportsLoginItemSettings()) return;
+  app.setLoginItemSettings({
+    openAtLogin: enabled,
+    openAsHidden: true
+  });
+}
+
+function getLaunchAtLoginState(fallback: boolean): boolean {
+  if (!supportsLoginItemSettings()) return fallback;
+  return app.getLoginItemSettings().openAtLogin;
+}
+
+function getSettingsWithSystemState(): Settings {
+  const settings = getSettings();
+  return {
+    ...settings,
+    launchAtLoginEnabled: getLaunchAtLoginState(settings.launchAtLoginEnabled)
+  };
 }
 
 function getStatsHistory(): StatsHistory {
@@ -197,7 +233,8 @@ function snapshot(): AppSnapshot {
       version: app.getVersion(),
       releaseNotesUrl: RELEASES_URL
     },
-    settings: getSettings(),
+    updateCheck,
+    settings: getSettingsWithSystemState(),
     stats: getStats(),
     statsHistory: getStatsHistory(),
     timers: {
@@ -813,6 +850,129 @@ function happyFeedback(message: string | null = pick(text().bubble.woof), after?
   }, 1900);
 }
 
+function normalizeVersion(version: string): string {
+  return version.trim().replace(/^v/i, "");
+}
+
+function compareVersions(left: string, right: string): number {
+  const [leftCore, leftPreRelease = ""] = normalizeVersion(left).split("-", 2);
+  const [rightCore, rightPreRelease = ""] = normalizeVersion(right).split("-", 2);
+  const leftParts = leftCore.split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const rightParts = rightCore.split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = leftParts[index] ?? 0;
+    const rightPart = rightParts[index] ?? 0;
+    if (leftPart > rightPart) return 1;
+    if (leftPart < rightPart) return -1;
+  }
+
+  if (!leftPreRelease && rightPreRelease) return 1;
+  if (leftPreRelease && !rightPreRelease) return -1;
+  return leftPreRelease.localeCompare(rightPreRelease);
+}
+
+function isGitHubReleasePayload(value: unknown): value is {
+  tag_name?: unknown;
+  html_url?: unknown;
+  name?: unknown;
+} {
+  return typeof value === "object" && value !== null;
+}
+
+function setUpdateCheck(next: UpdateCheckResult): void {
+  updateCheck = next;
+  publishSnapshot();
+}
+
+function openReleaseNotes(): void {
+  void shell.openExternal(updateCheck.releaseUrl || RELEASES_URL).catch((error) => {
+    console.error("Failed to open PawPal releases:", error);
+  });
+}
+
+function showUpdateAvailableNotice(result: UpdateCheckResult): void {
+  if (blockingMode || result.status !== "available" || !result.latestVersion) return;
+  ensurePetWindowVisible();
+  setPetState("happy");
+  showBubble({
+    id: "update-available",
+    message: pick(text().bubble.updateAvailable)(result.latestVersion),
+    actions: [
+      { id: "app:open-release-notes", label: text().settings.openReleaseNotes, kind: "primary" }
+    ],
+    autoDismissMs: 12000
+  });
+  setTimeout(() => {
+    if (!blockingMode && petState === "happy") setPetState(focusActive ? "focusGuard" : "idle");
+  }, 12_100);
+}
+
+async function checkForUpdates(options: { notifyAvailable?: boolean } = {}): Promise<UpdateCheckResult> {
+  setUpdateCheck({
+    ...updateCheck,
+    status: "checking",
+    currentVersion: app.getVersion(),
+    checkedAt: Date.now(),
+    error: null
+  });
+
+  try {
+    const response = await net.fetch(RELEASES_API_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": `${APP_NAME}/${app.getVersion()}`
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub returned ${response.status}`);
+    }
+
+    const payload: unknown = await response.json();
+    if (!isGitHubReleasePayload(payload)) {
+      throw new Error("Unexpected release response");
+    }
+
+    const latestVersion =
+      typeof payload.tag_name === "string"
+        ? payload.tag_name
+        : typeof payload.name === "string"
+          ? payload.name
+          : "";
+
+    if (!latestVersion) {
+      throw new Error("Latest release has no version tag");
+    }
+
+    const releaseUrl = typeof payload.html_url === "string" ? payload.html_url : RELEASES_URL;
+    const currentVersion = app.getVersion();
+    const result: UpdateCheckResult = {
+      status: compareVersions(latestVersion, currentVersion) > 0 ? "available" : "up-to-date",
+      currentVersion,
+      latestVersion,
+      releaseUrl,
+      checkedAt: Date.now(),
+      error: null
+    };
+
+    setUpdateCheck(result);
+    if (options.notifyAvailable) showUpdateAvailableNotice(result);
+    return result;
+  } catch (error) {
+    const result: UpdateCheckResult = {
+      ...updateCheck,
+      status: "error",
+      currentVersion: app.getVersion(),
+      checkedAt: Date.now(),
+      error: error instanceof Error ? error.message : String(error)
+    };
+    setUpdateCheck(result);
+    return result;
+  }
+}
+
 function triggerBreakReminder(fromDemo: boolean): void {
   if (blockingMode === "focusWarning" || blockingMode === "breakRun") return;
   if (!fromDemo && (focusActive || breakMutedToday)) {
@@ -942,6 +1102,12 @@ function triggerDemo(trigger: DemoTrigger): void {
 }
 
 function handleBubbleAction(actionId: string): void {
+  if (actionId === "app:open-release-notes") {
+    hideBubble();
+    setPetState(focusActive ? "focusGuard" : "idle");
+    openReleaseNotes();
+    return;
+  }
   if (actionId === "break-run:done") {
     finishBreakRun();
     return;
@@ -1012,11 +1178,8 @@ function handleBubbleAction(actionId: string): void {
 
 function registerIpc(): void {
   ipcMain.handle("app:get-snapshot", () => snapshot());
-  ipcMain.on("app:open-release-notes", () => {
-    void shell.openExternal(RELEASES_URL).catch((error) => {
-      console.error("Failed to open PawPal releases:", error);
-    });
-  });
+  ipcMain.handle("app:check-for-updates", () => checkForUpdates({ notifyAvailable: true }));
+  ipcMain.on("app:open-release-notes", openReleaseNotes);
   ipcMain.on("pet:clicked", () => {
     if (blockingMode) return;
     happyFeedback(null);
@@ -1070,6 +1233,9 @@ app.whenReady().then(() => {
   scheduleDistractionDetection();
   if (IS_DEV) {
     createSettingsWindow();
+  }
+  if (getSettings().checkUpdatesOnLaunchEnabled) {
+    setTimeout(() => void checkForUpdates({ notifyAvailable: true }), 1500);
   }
 
   app.on("activate", () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,7 +5,8 @@ import type {
   PetState,
   Settings,
   SpeechBubble,
-  TodayStats
+  TodayStats,
+  UpdateCheckResult
 } from "../shared/types";
 
 type Unsubscribe = () => void;
@@ -19,6 +20,7 @@ function onChannel<T>(channel: string, callback: (payload: T) => void): Unsubscr
 const api = {
   getSnapshot: (): Promise<AppSnapshot> => ipcRenderer.invoke("app:get-snapshot"),
   openReleaseNotes: (): void => ipcRenderer.send("app:open-release-notes"),
+  checkForUpdates: (): Promise<UpdateCheckResult> => ipcRenderer.invoke("app:check-for-updates"),
   petClicked: (): void => ipcRenderer.send("pet:clicked"),
   petContextMenu: (): void => ipcRenderer.send("pet:context-menu"),
   petDragStart: (offset: { offsetX: number; offsetY: number }): void =>

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -2,7 +2,12 @@ import { useEffect, useMemo, useState } from "react";
 import type { JSX, ReactNode } from "react";
 import { i18n, LANGUAGE_OPTIONS, resolveLanguage } from "../../../shared/i18n";
 import { petAppearanceOptions, resolvePetAppearanceId } from "../../../shared/petAppearances";
-import type { DemoTrigger, PetAppearanceId, Settings } from "../../../shared/types";
+import type {
+  DemoTrigger,
+  PetAppearanceId,
+  Settings,
+  UpdateCheckResult
+} from "../../../shared/types";
 import { getPetAsset } from "../assets";
 import { distractionHelp, formatDistractionState, formatTimer, formatTimestamp, localeFor } from "../format";
 import { useNow, useSnapshot } from "../hooks";
@@ -202,9 +207,23 @@ function StatCard({
   );
 }
 
+function formatUpdateStatus(updateCheck: UpdateCheckResult, labels: SettingsCopy): string {
+  if (updateCheck.status === "checking") return labels.updateChecking;
+  if (updateCheck.status === "available" && updateCheck.latestVersion) {
+    return labels.updateAvailable(updateCheck.latestVersion);
+  }
+  if (updateCheck.status === "up-to-date") {
+    return labels.updateCurrent(updateCheck.currentVersion);
+  }
+  if (updateCheck.status === "error") {
+    return labels.updateError(updateCheck.error ?? labels.none);
+  }
+  return labels.updateIdle;
+}
+
 export function SettingsView(): JSX.Element {
   const snapshot = useSnapshot();
-  const { settings, stats } = snapshot;
+  const { settings, stats, updateCheck } = snapshot;
   const [draft, setDraft] = useState(settings);
   const [settingsDirty, setSettingsDirty] = useState(false);
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
@@ -235,6 +254,10 @@ export function SettingsView(): JSX.Element {
   function updateDraft(partial: Partial<Settings>): void {
     setDraft((current) => ({ ...current, ...partial }));
     setSettingsDirty(true);
+  }
+
+  async function checkForUpdates(): Promise<void> {
+    await window.pawpal.checkForUpdates();
   }
 
   return (
@@ -441,11 +464,71 @@ export function SettingsView(): JSX.Element {
       )}
 
       <section className="prefs__group">
+        <h2 className="prefs__group-title">{labels.system}</h2>
+        <Row
+          label={labels.launchAtLogin}
+          hint={labels.launchAtLoginHelp}
+          control={
+            <ToggleControl
+              checked={draft.launchAtLoginEnabled}
+              onChange={(launchAtLoginEnabled) => updateDraft({ launchAtLoginEnabled })}
+              ariaLabel={labels.launchAtLogin}
+            />
+          }
+        />
+        <Row
+          label={labels.updateCheckOnLaunch}
+          hint={labels.updateCheckOnLaunchHelp}
+          control={
+            <ToggleControl
+              checked={draft.checkUpdatesOnLaunchEnabled}
+              onChange={(checkUpdatesOnLaunchEnabled) =>
+                updateDraft({ checkUpdatesOnLaunchEnabled })
+              }
+              ariaLabel={labels.updateCheckOnLaunch}
+            />
+          }
+        />
+      </section>
+
+      <section className="prefs__group">
         <h2 className="prefs__group-title">{labels.about}</h2>
         <Row
           label={labels.version}
+          hint={
+            updateCheck.latestVersion
+              ? labels.latestVersion(updateCheck.latestVersion)
+              : undefined
+          }
           control={
             <span className="pref-static-value">{snapshot.appInfo.version || labels.none}</span>
+          }
+        />
+        <Row
+          label={labels.updates}
+          hint={formatUpdateStatus(updateCheck, labels)}
+          control={
+            <div className="pref-button-group">
+              <button
+                type="button"
+                className="pref-button"
+                disabled={updateCheck.status === "checking"}
+                onClick={() => void checkForUpdates()}
+              >
+                {updateCheck.status === "checking"
+                  ? labels.checkingUpdates
+                  : labels.checkForUpdates}
+              </button>
+              {updateCheck.status === "available" ? (
+                <button
+                  type="button"
+                  className="pref-button is-primary"
+                  onClick={window.pawpal.openReleaseNotes}
+                >
+                  {labels.openReleaseNotes}
+                </button>
+              ) : null}
+            </div>
           }
         />
         <Row

--- a/src/renderer/src/hooks.ts
+++ b/src/renderer/src/hooks.ts
@@ -16,6 +16,14 @@ export function useSnapshot(): AppSnapshot {
       version: "",
       releaseNotesUrl: ""
     },
+    updateCheck: {
+      status: "idle",
+      currentVersion: "",
+      latestVersion: null,
+      releaseUrl: "",
+      checkedAt: null,
+      error: null
+    },
     settings: DEFAULT_SETTINGS,
     stats: initialStats,
     statsHistory: {},

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -716,6 +716,15 @@ textarea {
   border-color: var(--accent);
 }
 
+.pref-button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.pref-button:disabled:hover {
+  border-color: var(--rule-strong);
+}
+
 .pref-button.is-primary {
   background: var(--accent);
   border-color: var(--accent);
@@ -724,6 +733,13 @@ textarea {
 
 .pref-button.is-primary:hover {
   background: #a26d2c;
+}
+
+.pref-button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
 }
 
 .pref-chip-button {
@@ -906,6 +922,10 @@ textarea {
     justify-content: flex-start;
     max-width: 100%;
     width: 100%;
+  }
+
+  .pref-button-group {
+    justify-content: flex-start;
   }
 }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -4,6 +4,8 @@ export const DEFAULT_SETTINGS: Settings = {
   language: "zh-CN",
   petAppearanceId: "lineDog",
   onboardingDismissed: false,
+  launchAtLoginEnabled: false,
+  checkUpdatesOnLaunchEnabled: false,
   breakReminderEnabled: true,
   breakIntervalMinutes: 45,
   hydrationReminderEnabled: true,

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -75,6 +75,10 @@ export const I18N = {
         "好，我继续盯着~",
         "嗯！回去干活吧",
         "我也继续专心啦"
+      ],
+      updateAvailable: [
+        (version: string) => `发现新版本 ${version}，去看看更新吧`,
+        (version: string) => `PawPal 有新版本 ${version} 啦`
       ]
     },
     actions: {
@@ -107,10 +111,24 @@ export const I18N = {
         "PawPal 会住在菜单栏和屏幕底部，定时提醒你休息、喝水和保持专注。分心检测目前仅支持 macOS，需要在系统设置里允许辅助功能权限。",
       dismissWelcome: "知道了",
       appearance: "外观",
+      system: "系统",
+      launchAtLogin: "开机自启",
+      launchAtLoginHelp: "正式打包版本会在 macOS 或 Windows 登录后启动；开发环境只保存偏好，不注册系统登录项。",
       about: "关于",
       version: "版本",
       releaseNotes: "更新说明",
       openReleaseNotes: "打开 Releases",
+      updates: "更新",
+      checkForUpdates: "检查更新",
+      checkingUpdates: "检查中…",
+      updateCheckOnLaunch: "启动时检查更新",
+      updateCheckOnLaunchHelp: "开启后每次启动会检查 GitHub 最新 Release；关闭时只在你手动检查时联网。",
+      updateIdle: "还没有检查更新。",
+      updateAvailable: (version: string) => `发现新版本 ${version}`,
+      updateCurrent: (version: string) => `已是最新版本 ${version}`,
+      updateError: (message: string) => `检查失败：${message}`,
+      updateChecking: "正在检查 GitHub Releases…",
+      latestVersion: (version: string) => `最新版本：${version}`,
       quickActions: "快捷操作",
       testTools: "测试工具",
       language: "语言",
@@ -250,6 +268,10 @@ export const I18N = {
         "Good, I'll keep watching~",
         "Mm! Back to work then",
         "I'll keep focusing too~"
+      ],
+      updateAvailable: [
+        (version: string) => `Version ${version} is available. Want to see what's new?`,
+        (version: string) => `PawPal has a new version: ${version}.`
       ]
     },
     actions: {
@@ -282,10 +304,26 @@ export const I18N = {
         "PawPal lives in the menu bar and near the bottom of your screen. It reminds you to take breaks, drink water, and stay focused. Distraction detection is macOS-only and requires accessibility permissions.",
       dismissWelcome: "Got it",
       appearance: "Appearance",
+      system: "System",
+      launchAtLogin: "Launch at Login",
+      launchAtLoginHelp:
+        "Packaged macOS and Windows builds will start after login. Development builds only save the preference.",
       about: "About",
       version: "Version",
       releaseNotes: "Release Notes",
       openReleaseNotes: "Open Releases",
+      updates: "Updates",
+      checkForUpdates: "Check for Updates",
+      checkingUpdates: "Checking…",
+      updateCheckOnLaunch: "Check Updates on Launch",
+      updateCheckOnLaunchHelp:
+        "When enabled, PawPal checks the latest GitHub Release on startup. Otherwise it only checks when you ask.",
+      updateIdle: "Updates have not been checked yet.",
+      updateAvailable: (version: string) => `Version ${version} is available.`,
+      updateCurrent: (version: string) => `You are on the latest version ${version}.`,
+      updateError: (message: string) => `Update check failed: ${message}`,
+      updateChecking: "Checking GitHub Releases…",
+      latestVersion: (version: string) => `Latest version: ${version}`,
       quickActions: "Quick Actions",
       testTools: "Test Tools",
       language: "Language",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -39,6 +39,8 @@ export type Settings = {
   language: Language;
   petAppearanceId: PetAppearanceId;
   onboardingDismissed: boolean;
+  launchAtLoginEnabled: boolean;
+  checkUpdatesOnLaunchEnabled: boolean;
   breakReminderEnabled: boolean;
   breakIntervalMinutes: number;
   hydrationReminderEnabled: boolean;
@@ -78,6 +80,7 @@ export type DistractionStatus = {
 
 export type AppSnapshot = {
   appInfo: AppInfo;
+  updateCheck: UpdateCheckResult;
   settings: Settings;
   stats: TodayStats;
   statsHistory: StatsHistory;
@@ -93,6 +96,22 @@ export type AppSnapshot = {
 export type AppInfo = {
   version: string;
   releaseNotesUrl: string;
+};
+
+export type UpdateCheckStatus =
+  | "idle"
+  | "checking"
+  | "available"
+  | "up-to-date"
+  | "error";
+
+export type UpdateCheckResult = {
+  status: UpdateCheckStatus;
+  currentVersion: string;
+  latestVersion: string | null;
+  releaseUrl: string;
+  checkedAt: number | null;
+  error: string | null;
 };
 
 export type DemoTrigger =


### PR DESCRIPTION
## Summary
- add lightweight GitHub Releases update checks with manual and opt-in launch-time flows
- add app/system settings for version info, release notes, and launch at login on packaged macOS/Windows builds
- expose update status through the preload snapshot and renderer settings UI

## Issues
Closes #2
Closes #3

Note: #6 was already closed as addressed by PR #12.

## Validation
- pnpm run typecheck
- pnpm run build