### PR TITLE
fix: keep pet visible across display changes

### DIFF
--- a/src/main/displayPosition.ts
+++ b/src/main/displayPosition.ts
@@ -1,0 +1,167 @@
+export type WindowBounds = {
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+};
+
+export type WorkArea = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type DisplayBounds = {
+  id: number;
+  workArea: WorkArea;
+};
+
+export type SavedWindowPosition = {
+  x: number;
+  y: number;
+  displayId?: number;
+  relativeX?: number;
+  relativeY?: number;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function center(bounds: WindowBounds): { x: number; y: number } {
+  return {
+    x: bounds.x + Math.round(bounds.width / 2),
+    y: bounds.y + Math.round(bounds.height / 2)
+  };
+}
+
+function containsPoint(workArea: WorkArea, point: { x: number; y: number }): boolean {
+  return (
+    point.x >= workArea.x &&
+    point.x <= workArea.x + workArea.width &&
+    point.y >= workArea.y &&
+    point.y <= workArea.y + workArea.height
+  );
+}
+
+function distanceToWorkArea(workArea: WorkArea, point: { x: number; y: number }): number {
+  const dx =
+    point.x < workArea.x
+      ? workArea.x - point.x
+      : point.x > workArea.x + workArea.width
+        ? point.x - (workArea.x + workArea.width)
+        : 0;
+  const dy =
+    point.y < workArea.y
+      ? workArea.y - point.y
+      : point.y > workArea.y + workArea.height
+        ? point.y - (workArea.y + workArea.height)
+        : 0;
+  return Math.hypot(dx, dy);
+}
+
+export function displayForBounds(
+  displays: DisplayBounds[],
+  bounds: WindowBounds,
+  fallback: DisplayBounds
+): DisplayBounds {
+  const point = center(bounds);
+  return (
+    displays.find((display) => containsPoint(display.workArea, point)) ??
+    [...displays].sort((left, right) => {
+      return distanceToWorkArea(left.workArea, point) - distanceToWorkArea(right.workArea, point);
+    })[0] ??
+    fallback
+  );
+}
+
+export function clampBoundsToWorkArea(bounds: WindowBounds, workArea: WorkArea): WindowBounds {
+  return {
+    ...bounds,
+    x: clamp(bounds.x, workArea.x, workArea.x + workArea.width - bounds.width),
+    y: clamp(bounds.y, workArea.y, workArea.y + workArea.height - bounds.height)
+  };
+}
+
+export function savedPositionFromBounds(
+  displays: DisplayBounds[],
+  bounds: WindowBounds,
+  fallback: DisplayBounds
+): SavedWindowPosition {
+  const display = displayForBounds(displays, bounds, fallback);
+  const maxX = Math.max(1, display.workArea.width - bounds.width);
+  const maxY = Math.max(1, display.workArea.height - bounds.height);
+
+  return {
+    x: bounds.x,
+    y: bounds.y,
+    displayId: display.id,
+    relativeX: clamp((bounds.x - display.workArea.x) / maxX, 0, 1),
+    relativeY: clamp((bounds.y - display.workArea.y) / maxY, 0, 1)
+  };
+}
+
+export function initialWindowBounds({
+  displays,
+  primaryDisplay,
+  size,
+  saved
+}: {
+  displays: DisplayBounds[];
+  primaryDisplay: DisplayBounds;
+  size: { width: number; height: number };
+  saved?: SavedWindowPosition;
+}): WindowBounds {
+  const fallback: WindowBounds = {
+    width: size.width,
+    height: size.height,
+    x: Math.round(primaryDisplay.workArea.x + primaryDisplay.workArea.width / 2 - size.width / 2),
+    y: primaryDisplay.workArea.y + primaryDisplay.workArea.height - size.height
+  };
+
+  if (!saved) return fallback;
+
+  const savedDisplay =
+    typeof saved.displayId === "number"
+      ? displays.find((display) => display.id === saved.displayId)
+      : undefined;
+  const targetDisplay = savedDisplay ?? displayForBounds(displays, { ...fallback, x: saved.x, y: saved.y }, primaryDisplay);
+  const hasRelativePosition =
+    typeof saved.relativeX === "number" &&
+    Number.isFinite(saved.relativeX) &&
+    typeof saved.relativeY === "number" &&
+    Number.isFinite(saved.relativeY);
+  const restored: WindowBounds =
+    savedDisplay && hasRelativePosition
+      ? {
+          ...fallback,
+          x: Math.round(
+            targetDisplay.workArea.x +
+              clamp(saved.relativeX ?? 0, 0, 1) *
+                Math.max(0, targetDisplay.workArea.width - size.width)
+          ),
+          y: Math.round(
+            targetDisplay.workArea.y +
+              clamp(saved.relativeY ?? 0, 0, 1) *
+                Math.max(0, targetDisplay.workArea.height - size.height)
+          )
+        }
+      : {
+          ...fallback,
+          x: saved.x,
+          y: saved.y
+        };
+
+  return clampBoundsToWorkArea(restored, targetDisplay.workArea);
+}
+
+export function visibleWindowBounds(
+  displays: DisplayBounds[],
+  primaryDisplay: DisplayBounds,
+  bounds: WindowBounds
+): WindowBounds {
+  const targetDisplay = displayForBounds(displays, bounds, primaryDisplay);
+  return clampBoundsToWorkArea(bounds, targetDisplay.workArea);
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -45,6 +45,12 @@ import {
   SETTINGS_WINDOW,
   STORE_NAME
 } from "./config";
+import {
+  initialWindowBounds,
+  savedPositionFromBounds,
+  visibleWindowBounds
+} from "./displayPosition";
+import type { DisplayBounds, SavedWindowPosition } from "./displayPosition";
 import { classifyDistraction, isPermissionError, readActiveWindow } from "./distraction";
 import { applyLaunchAtLoginPreference, getLaunchAtLoginState } from "./loginItem";
 import {
@@ -66,16 +72,16 @@ import {
   createInitialUpdateCheck
 } from "./updates";
 
-type PetPosition = {
-  x: number;
-  y: number;
-};
-
 type StoreSchema = {
   settings: Settings;
   stats: TodayStats;
   statsHistory: StatsHistory;
-  petPosition?: PetPosition;
+  petPosition?: SavedWindowPosition;
+};
+
+type PetPosition = {
+  x: number;
+  y: number;
 };
 
 app.setName(APP_NAME);
@@ -105,6 +111,7 @@ let hydrationTimer: NodeJS.Timeout | null = null;
 let focusTimer: NodeJS.Timeout | null = null;
 let distractionTimer: NodeJS.Timeout | null = null;
 let distractionStartupTimer: NodeJS.Timeout | null = null;
+let displayChangeTimer: NodeJS.Timeout | null = null;
 let breakDueAt: number | null = null;
 let hydrationDueAt: number | null = null;
 let focusEndsAt: number | null = null;
@@ -251,41 +258,60 @@ function loadRenderer(win: BrowserWindow, route: "pet" | "settings"): void {
   void win.loadFile(rendererUrl(route), { hash: route });
 }
 
-function clampBoundsToWorkArea(bounds: Electron.Rectangle): Electron.Rectangle {
-  const center = {
-    x: bounds.x + Math.round(bounds.width / 2),
-    y: bounds.y + Math.round(bounds.height / 2)
-  };
-  const workArea = screen.getDisplayNearestPoint(center).workArea;
+function toDisplayBounds(display: Electron.Display): DisplayBounds {
   return {
-    ...bounds,
-    x: Math.min(Math.max(bounds.x, workArea.x), workArea.x + workArea.width - bounds.width),
-    y: Math.min(Math.max(bounds.y, workArea.y), workArea.y + workArea.height - bounds.height)
+    id: display.id,
+    workArea: display.workArea
   };
 }
 
-function initialPetBounds(): Electron.Rectangle {
-  const workArea = screen.getPrimaryDisplay().workArea;
-  const stored = store.get("petPosition");
-  const fallback = {
-    width: PET_WINDOW.width,
-    height: PET_WINDOW.height,
-    x: Math.round(workArea.x + workArea.width / 2 - PET_WINDOW.width / 2),
-    y: workArea.y + workArea.height - PET_WINDOW.height
-  };
+function currentDisplays(): DisplayBounds[] {
+  return screen.getAllDisplays().map(toDisplayBounds);
+}
 
-  if (!stored) return fallback;
-  return clampBoundsToWorkArea({
-    ...fallback,
-    x: stored.x,
-    y: stored.y
+function primaryDisplay(): DisplayBounds {
+  return toDisplayBounds(screen.getPrimaryDisplay());
+}
+
+function initialPetBounds(): Electron.Rectangle {
+  const stored = store.get("petPosition");
+  return initialWindowBounds({
+    displays: currentDisplays(),
+    primaryDisplay: primaryDisplay(),
+    size: PET_WINDOW,
+    saved: stored
   });
 }
 
 function persistPetPosition(): void {
   if (!petWindow || petWindow.isDestroyed()) return;
   const bounds = petWindow.getBounds();
-  store.set("petPosition", { x: bounds.x, y: bounds.y });
+  store.set("petPosition", savedPositionFromBounds(currentDisplays(), bounds, primaryDisplay()));
+}
+
+function keepPetWindowInVisibleWorkArea(): void {
+  if (!petWindow || petWindow.isDestroyed()) return;
+  const bounds = petWindow.getBounds();
+  const nextBounds = visibleWindowBounds(currentDisplays(), primaryDisplay(), bounds);
+  if (bounds.x !== nextBounds.x || bounds.y !== nextBounds.y) {
+    petWindow.setBounds(nextBounds);
+  }
+  persistPetPosition();
+  publishSnapshot();
+}
+
+function schedulePetDisplayRepair(): void {
+  if (displayChangeTimer) clearTimeout(displayChangeTimer);
+  displayChangeTimer = setTimeout(() => {
+    displayChangeTimer = null;
+    keepPetWindowInVisibleWorkArea();
+  }, 250);
+}
+
+function registerDisplayChangeHandlers(): void {
+  screen.on("display-added", schedulePetDisplayRepair);
+  screen.on("display-removed", schedulePetDisplayRepair);
+  screen.on("display-metrics-changed", schedulePetDisplayRepair);
 }
 
 function createPetWindow(): void {
@@ -460,7 +486,7 @@ function showPetContextMenu(): void {
 function movePetWithCursor(): void {
   if (!petWindow || petWindow.isDestroyed()) return;
   const cursor = screen.getCursorScreenPoint();
-  const bounds = clampBoundsToWorkArea({
+  const bounds = visibleWindowBounds(currentDisplays(), primaryDisplay(), {
     width: PET_WINDOW.width,
     height: PET_WINDOW.height,
     x: cursor.x - dragOffset.x,
@@ -1038,6 +1064,7 @@ app.whenReady().then(() => {
   registerIpc();
   createPetWindow();
   createTray();
+  registerDisplayChangeHandlers();
   scheduleReminderTimers();
   scheduleDistractionDetection();
   if (IS_DEV) {
@@ -1062,6 +1089,7 @@ app.on("before-quit", () => {
     focusTimer,
     distractionTimer,
     distractionStartupTimer,
+    displayChangeTimer,
     bubbleTimer,
     dragTimer,
     dragSafetyTimer

--- a/tests/displayPosition.test.ts
+++ b/tests/displayPosition.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import {
+  initialWindowBounds,
+  savedPositionFromBounds,
+  visibleWindowBounds
+} from "../src/main/displayPosition";
+import type { DisplayBounds, WindowBounds } from "../src/main/displayPosition";
+
+const primary: DisplayBounds = {
+  id: 1,
+  workArea: { x: 0, y: 0, width: 1440, height: 900 }
+};
+
+const secondary: DisplayBounds = {
+  id: 2,
+  workArea: { x: 1440, y: 0, width: 1280, height: 900 }
+};
+
+const petSize = { width: 220, height: 340 };
+
+export const tests = [
+  {
+    name: "visibleWindowBounds moves a pet from a removed display back into the primary work area",
+    run(): void {
+      const offscreen: WindowBounds = { ...petSize, x: 2400, y: 560 };
+
+      const bounds = visibleWindowBounds([primary], primary, offscreen);
+
+      assert.equal(bounds.x, 1220);
+      assert.equal(bounds.y, 560);
+    }
+  },
+  {
+    name: "savedPositionFromBounds stores display id and relative coordinates",
+    run(): void {
+      const saved = savedPositionFromBounds(
+        [primary, secondary],
+        { ...petSize, x: 2080, y: 280 },
+        primary
+      );
+
+      assert.equal(saved.displayId, secondary.id);
+      assert.ok(typeof saved.relativeX === "number");
+      assert.ok(typeof saved.relativeY === "number");
+    }
+  },
+  {
+    name: "initialWindowBounds restores relative position on the same display after resolution changes",
+    run(): void {
+      const saved = savedPositionFromBounds(
+        [primary, secondary],
+        { ...petSize, x: 2080, y: 280 },
+        primary
+      );
+      const resizedSecondary: DisplayBounds = {
+        id: secondary.id,
+        workArea: { x: 1440, y: 0, width: 1600, height: 1000 }
+      };
+
+      const restored = initialWindowBounds({
+        displays: [primary, resizedSecondary],
+        primaryDisplay: primary,
+        size: petSize,
+        saved
+      });
+
+      assert.equal(restored.x > resizedSecondary.workArea.x, true);
+      assert.equal(restored.x < resizedSecondary.workArea.x + resizedSecondary.workArea.width, true);
+      assert.equal(restored.y > resizedSecondary.workArea.y, true);
+      assert.equal(restored.y < resizedSecondary.workArea.y + resizedSecondary.workArea.height, true);
+    }
+  },
+  {
+    name: "initialWindowBounds falls back to nearest visible display when the saved display no longer exists",
+    run(): void {
+      const bounds = initialWindowBounds({
+        displays: [primary],
+        primaryDisplay: primary,
+        size: petSize,
+        saved: {
+          x: 2400,
+          y: 560,
+          displayId: secondary.id,
+          relativeX: 0.5,
+          relativeY: 1
+        }
+      });
+
+      assert.equal(bounds.x, 1220);
+      assert.equal(bounds.y, 560);
+    }
+  }
+];


### PR DESCRIPTION
## Summary
- keep the pet window inside a visible work area after display add/remove/metrics changes
- persist display id and relative position so saved positions survive resolution and dock/menu changes
- add pure positioning tests for removed displays, relative restore, and fallback behavior

Closes #5

## Validation
- pnpm run test
- pnpm run typecheck
- pnpm run build
- pnpm dev smoke test